### PR TITLE
chore: loosen graphql dependency

### DIFF
--- a/graphql-connections.gemspec
+++ b/graphql-connections.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = "> 2.5"
 
   spec.add_runtime_dependency "activerecord", ">= 5"
-  spec.add_runtime_dependency "graphql", "~> 1.10"
+  spec.add_runtime_dependency "graphql", [">= 1.10", "< 3.0"]
 
   spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "factory_bot_rails", "~> 6.2"


### PR DESCRIPTION
# Context

Loosen graphql dependency to support v2

https://github.com/rmosolgo/graphql-ruby/blob/master/CHANGELOG.md#200-9-february-2022

# What's inside

- [x] Loosen graphql dependency

# Checklist:

- [ ] I have added tests
- [ ] I have made corresponding changes to the documentation
