### PR TITLE
Fix GraphQL::Connections::PrimaryKey#has_next_page

### DIFF
--- a/lib/graphql/connections/primary_key/base.rb
+++ b/lib/graphql/connections/primary_key/base.rb
@@ -27,7 +27,7 @@ module GraphQL
 
         def has_next_page
           if first
-            items_exist?(type: :query, search: nodes.last[primary_key], page_type: :next)
+            nodes.any? && items_exist?(type: :query, search: nodes.last[primary_key], page_type: :next)
           elsif before
             items_exist?(type: :cursor, search: before_cursor, page_type: :next)
           else

--- a/lib/graphql/connections/version.rb
+++ b/lib/graphql/connections/version.rb
@@ -2,6 +2,6 @@
 
 module GraphQL
   module Paging
-    VERSION = "1.3.0"
+    VERSION = "1.3.1"
   end
 end


### PR DESCRIPTION
`has_next_page` method raises exception when `nodes` is blank.