### PR TITLE
Protect against empty sets

### DIFF
--- a/lib/graphql/connections/primary_key/base.rb
+++ b/lib/graphql/connections/primary_key/base.rb
@@ -16,20 +16,24 @@ module GraphQL
         end
 
         def has_previous_page
+          return false if nodes.empty?
+          
           if last
-            nodes.any? && items_exist?(type: :query, search: nodes.first[primary_key], page_type: :previous)
+            items_exist?(type: :query, search: nodes.first[primary_key], page_type: :previous)
           elsif after
-            nodes.any? && items_exist?(type: :cursor, search: after_cursor, page_type: :previous)
+            items_exist?(type: :cursor, search: after_cursor, page_type: :previous)
           else
             false
           end
         end
 
         def has_next_page
+          return false if nodes.empty?
+
           if first
-            nodes.any? && items_exist?(type: :query, search: nodes.last[primary_key], page_type: :next)
+            items_exist?(type: :query, search: nodes.last[primary_key], page_type: :next)
           elsif before
-            nodes.any? && items_exist?(type: :cursor, search: before_cursor, page_type: :next)
+            items_exist?(type: :cursor, search: before_cursor, page_type: :next)
           else
             false
           end

--- a/lib/graphql/connections/primary_key/base.rb
+++ b/lib/graphql/connections/primary_key/base.rb
@@ -19,7 +19,7 @@ module GraphQL
           if last
             nodes.any? && items_exist?(type: :query, search: nodes.first[primary_key], page_type: :previous)
           elsif after
-            items_exist?(type: :cursor, search: after_cursor, page_type: :previous)
+            nodes.any? && items_exist?(type: :cursor, search: after_cursor, page_type: :previous)
           else
             false
           end
@@ -27,9 +27,9 @@ module GraphQL
 
         def has_next_page
           if first
-            items_exist?(type: :query, search: nodes.last[primary_key], page_type: :next)
+            nodes.any? && items_exist?(type: :query, search: nodes.last[primary_key], page_type: :next)
           elsif before
-            items_exist?(type: :cursor, search: before_cursor, page_type: :next)
+            nodes.any? && items_exist?(type: :cursor, search: before_cursor, page_type: :next)
           else
             false
           end


### PR DESCRIPTION
# Context

Prevent raising an error when nodes is empty

I have tests on my local but cannot push them due to permissions on this repository.

This can go in both `spec/lib/primary_key/desc_spec.rb` and `spec/lib/primary_key/asc_spec.rb`

```Ruby
describe "when nodes is empty" do
  let(:params) { {first: 2} }
  let(:relation) { Message.none }

  it "returns no nodes and has_previous_page and has_next_page are false" do
    expect(nodes.size).to eq 0
    expect(connection.has_previous_page).to be false
    expect(connection.has_next_page).to be false
  end
end
```

## Related tickets

Closes https://github.com/bibendi/graphql-connections/issues/12
