### PR TITLE
fix: support empty nodes

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.6', '2.7', '3.0', '3.1', '3.2' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
     env:
       RUBY_IMAGE: ${{ matrix.ruby }}
     name: Ruby ${{ matrix.ruby }}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
+        ruby: [ '3.0', '3.1', '3.2' ]
     env:
       RUBY_IMAGE: ${{ matrix.ruby }}
     name: Ruby ${{ matrix.ruby }}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,7 +17,7 @@ jobs:
       RUBY_IMAGE: ${{ matrix.ruby }}
     name: Ruby ${{ matrix.ruby }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.6', '2.7', '3.0' ]
+        ruby: [ '2.6', '2.7', '3.0', '3.1', '3.2' ]
     env:
       RUBY_IMAGE: ${{ matrix.ruby }}
     name: Ruby ${{ matrix.ruby }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /gemfiles/
 /pkg/
 /spec/reports/
+/spec/internal/tmp/
 /tmp/
 .pry_history
 .rspec_status

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,1 +1,1 @@
-ruby_version: 2.6
+ruby_version: 2.7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ruby:
-    image: ruby:${RUBY_IMAGE:-2.6}-bullseye
+    image: ruby:${RUBY_IMAGE:-2.7}-bullseye
     environment:
       HISTFILE: /app/.bash_history
       BUNDLE_PATH: /bundle

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ruby:
-    image: ruby:${RUBY_IMAGE:-3.0}-buster
+    image: ruby:${RUBY_IMAGE:-3.2}-bookworm
     environment:
       HISTFILE: /app/.bash_history
       BUNDLE_PATH: /bundle

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ruby:
-    image: ruby:${RUBY_IMAGE:-3.2}-bookworm
+    image: ruby:${RUBY_IMAGE:-3.2}-bullseye
     environment:
       HISTFILE: /app/.bash_history
       BUNDLE_PATH: /bundle

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ruby:
-    image: ruby:${RUBY_IMAGE:-3.2}-bullseye
+    image: ruby:${RUBY_IMAGE:-2.6}-bullseye
     environment:
       HISTFILE: /app/.bash_history
       BUNDLE_PATH: /bundle

--- a/graphql-connections.gemspec
+++ b/graphql-connections.gemspec
@@ -43,6 +43,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec-rails", "~> 6.0"
   spec.add_development_dependency "standard", "~> 1.1"
-  spec.add_development_dependency "test-prof", "~> 1.0"
+  spec.add_development_dependency "test-prof", "~> 1.0.0"
 end
 # rubocop:enable Metrics/BlockLength

--- a/graphql-connections.gemspec
+++ b/graphql-connections.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pg", "~> 1.2"
   spec.add_development_dependency "pry-byebug", "~> 3"
   spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rspec-rails", "~> 5.0"
+  spec.add_development_dependency "rspec-rails", "~> 6.0"
   spec.add_development_dependency "standard", "~> 1.1"
   spec.add_development_dependency "test-prof", "~> 1.0"
 end

--- a/graphql-connections.gemspec
+++ b/graphql-connections.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = "> 2.5"
+  spec.required_ruby_version = "> 2.6"
 
   spec.add_runtime_dependency "activerecord", ">= 5"
   spec.add_runtime_dependency "graphql", [">= 1.10", "< 3.0"]

--- a/lefthook-local.dip_example.yml
+++ b/lefthook-local.dip_example.yml
@@ -1,4 +1,4 @@
 pre-commit:
   commands:
     rubocop:
-      runner: dip {cmd}
+      run: dip {cmd}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,4 +3,4 @@ pre-commit:
     rubocop:
       tags: backend
       glob: "**/*.rb"
-      runner: bundle exec standardrb --fix {staged_files} && git add {staged_files}
+      run: bundle exec standardrb --fix {staged_files} && git add {staged_files}

--- a/lib/graphql/connections/keyset/asc.rb
+++ b/lib/graphql/connections/keyset/asc.rb
@@ -42,10 +42,10 @@ module GraphQL
             false
           end
         end
-        # rubocop:enable Naming/PredicateName, Metrics/AbcSize, Metrics/MethodLength
 
         private
 
+        # standard:disable Metrics/AbcSize, Metrics/MethodLength
         def limited_relation
           scope = sliced_relation
           nodes = []
@@ -78,6 +78,7 @@ module GraphQL
             .where(arel_table[primary_key].lt(before_cursor_primary_key))
             .or(relation.where(arel_table[field_key].lt(before_cursor_date)))
         end
+        # standard:enable Metrics/AbcSize, Metrics/MethodLength
       end
     end
   end

--- a/lib/graphql/connections/keyset/desc.rb
+++ b/lib/graphql/connections/keyset/desc.rb
@@ -42,8 +42,8 @@ module GraphQL
             false
           end
         end
-        # rubocop:enable Naming/PredicateName, Metrics/AbcSize, Metrics/MethodLength
 
+        # standard:disable Metrics/AbcSize, Metrics/MethodLength
         def cursor_for(item)
           cursor = [item[field_key], item[primary_key]].map { |value| serialize(value) }.join(@separator)
           cursor = encode(cursor) if opaque_cursor
@@ -85,6 +85,7 @@ module GraphQL
             .where(arel_table[primary_key].gt(before_cursor_primary_key))
             .or(relation.where(arel_table[field_key].gt(before_cursor_date)))
         end
+        # standard:disable Metrics/AbcSize, Metrics/MethodLength
       end
     end
   end

--- a/lib/graphql/connections/primary_key/base.rb
+++ b/lib/graphql/connections/primary_key/base.rb
@@ -16,8 +16,10 @@ module GraphQL
         end
 
         def has_previous_page
+          return false if nodes.empty?
+
           if last
-            nodes.any? && items_exist?(type: :query, search: nodes.first[primary_key], page_type: :previous)
+            items_exist?(type: :query, search: nodes.first[primary_key], page_type: :previous)
           elsif after
             items_exist?(type: :cursor, search: after_cursor, page_type: :previous)
           else
@@ -26,6 +28,8 @@ module GraphQL
         end
 
         def has_next_page
+          return false if nodes.empty?
+
           if first
             items_exist?(type: :query, search: nodes.last[primary_key], page_type: :next)
           elsif before

--- a/spec/lib/keyset/desc_spec.rb
+++ b/spec/lib/keyset/desc_spec.rb
@@ -26,6 +26,16 @@ describe GraphQL::Connections::Keyset::Desc do
       expect(connection.has_previous_page).to be false
       expect(connection.has_next_page).to be true
     end
+
+    context "with empty relation" do
+      let(:relation) { Message.none }
+
+      it "returns no nodes and has_previous_page and has_next_page are false" do
+        expect(nodes.size).to eq 0
+        expect(connection.has_previous_page).to be false
+        expect(connection.has_next_page).to be false
+      end
+    end
   end
 
   describe ":first param" do

--- a/spec/lib/primary_key/asc_spec.rb
+++ b/spec/lib/primary_key/asc_spec.rb
@@ -26,6 +26,16 @@ describe GraphQL::Connections::PrimaryKey::Asc do
       expect(connection.has_previous_page).to be false
       expect(connection.has_next_page).to be true
     end
+
+    context "with empty relation" do
+      let(:relation) { Message.none }
+
+      it "returns no nodes and has_previous_page and has_next_page are false" do
+        expect(nodes.size).to eq 0
+        expect(connection.has_previous_page).to be false
+        expect(connection.has_next_page).to be false
+      end
+    end
   end
 
   describe ":first param" do


### PR DESCRIPTION
Fixes https://github.com/evilmartians/graphql-connections/issues/12

# Context

`GraphQL::Connections::Stable` fails when empty relation is passed. This PR fixes it.
## Related tickets

https://github.com/evilmartians/graphql-connections/issues/12

# What's inside

<!--
List of features and changes (or highlights) (from the code perspective)
The purpose of this list is to track the progress if it's WIP (use checkboxes)
and to emphasize the critical parts (which you'd like to pay reviewers attention to)
-->
- [x] Simply return `false` if nodes are empty
- [x] Fix some versions of gems and Docker containers to do local development with dip
- [x] Drop support for Ruby 2.6

# Checklist:

- [x] I have added tests
- [ ] I have made corresponding changes to the documentation
